### PR TITLE
Feature/kubosuke/binary search

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -15,16 +16,38 @@ const (
 	LAYOUT       = "2006-01-02 15:04:05.999999999"
 )
 
+type SafeFile struct {
+	Mu sync.Mutex
+}
+
+func (sf *SafeFile) Write(s string) (int, error) {
+	sf.Mu.Lock()
+	defer sf.Mu.Unlock()
+
+	f, err := os.OpenFile(COUNTER_FILE, os.O_APPEND+os.O_WRONLY+os.O_CREATE, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	return f.WriteString(s)
+}
+
+func (sf *SafeFile) ReadAll() ([]byte, error) {
+	f, err := os.OpenFile(COUNTER_FILE, os.O_RDONLY+os.O_CREATE, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return io.ReadAll(f)
+}
+
 func counter(w http.ResponseWriter, r *http.Request) {
 	// time
 	time_current := time.Now()
 
 	// Read file
-	f, err := os.OpenFile(COUNTER_FILE, os.O_RDWR+os.O_CREATE, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-	b, err := io.ReadAll(f)
+	sf := new(SafeFile)
+	b, err := sf.ReadAll()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,7 +72,7 @@ func counter(w http.ResponseWriter, r *http.Request) {
 
 	// Write file and response
 	fmt.Fprintln(w, result)
-	if _, err = f.WriteString(fmt.Sprintln(time_current.Format(LAYOUT))); err != nil {
+	if _, err = sf.Write(fmt.Sprintln(time_current.Format(LAYOUT))); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -33,19 +33,23 @@ func counter(w http.ResponseWriter, r *http.Request) {
 
 	// count last 1 min
 	time_1min_ago := time_current.Add(-time.Second)
-	var idx = 0
 	timezone, _ := time.LoadLocation("Local")
-	for i, line := range lines {
-		idx = i
-		t, err := time.ParseInLocation(LAYOUT, line, timezone)
+
+	left := 0
+	right := len(lines) - 1
+	for left <= right {
+		mid := (left + right) / 2
+		t, err := time.ParseInLocation(LAYOUT, lines[mid], timezone)
 		if err != nil {
 			log.Fatal(err)
 		}
 		if t.After(time_1min_ago) {
-			break
+			right = mid - 1
+		} else {
+			left = mid + 1
 		}
 	}
-	result := len(lines) - idx - 1
+	result := len(lines) - left
 
 	// Write file and response
 	fmt.Fprintln(w, result)

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func counter(w http.ResponseWriter, r *http.Request) {
 	lines = lines[:len(lines)-1]
 
 	// count last 1 min
-	time_1min_ago := time_current.Add(-time.Second)
+	time_1min_ago := time_current.Add(-time.Minute)
 	var idx = 0
 	timezone, _ := time.LoadLocation("Local")
 	for i, line := range lines {

--- a/main.go
+++ b/main.go
@@ -42,10 +42,8 @@ func (sf *SafeFile) ReadAll() ([]byte, error) {
 }
 
 func counter(w http.ResponseWriter, r *http.Request) {
-	// time
 	time_current := time.Now()
 
-	// Read file
 	sf := new(SafeFile)
 	b, err := sf.ReadAll()
 	if err != nil {
@@ -54,7 +52,6 @@ func counter(w http.ResponseWriter, r *http.Request) {
 	lines := strings.Split(string(b), "\n")
 	lines = lines[:len(lines)-1]
 
-	// count last 1 min
 	time_1min_ago := time_current.Add(-time.Minute)
 	var idx = 0
 	timezone, _ := time.LoadLocation("Local")
@@ -70,7 +67,6 @@ func counter(w http.ResponseWriter, r *http.Request) {
 	}
 	result := len(lines) - idx - 1
 
-	// Write file and response
 	fmt.Fprintln(w, result)
 	if _, err = sf.Write(fmt.Sprintln(time_current.Format(LAYOUT))); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ const (
 )
 
 type SafeFile struct {
-	Mu sync.Mutex
+	mu sync.Mutex
 }
 
 func (sf *SafeFile) Write(s string) (int, error) {
-	sf.Mu.Lock()
-	defer sf.Mu.Unlock()
+	sf.mu.Lock()
+	defer sf.mu.Unlock()
 
 	f, err := os.OpenFile(COUNTER_FILE, os.O_APPEND+os.O_WRONLY+os.O_CREATE, 0666)
 	if err != nil {


### PR DESCRIPTION
# Overview

currently fetching the number of last 1min requests sequentially,
this PR is for enhance performance by introducing binary search.

time complexity: O(N) => O(logN)

# Test

100rps up to 30k

## Before (O(N))

```
❯ ab -c 100 -n 15000 http://localhost:8080/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 1500 requests
Completed 3000 requests
Completed 4500 requests
Completed 6000 requests
Completed 7500 requests
Completed 9000 requests
Completed 10500 requests
Completed 12000 requests
Completed 13500 requests
Completed 15000 requests
Finished 15000 requests


Server Software:
Server Hostname:        localhost
Server Port:            8080

Document Path:          /
Document Length:        3 bytes

Concurrency Level:      100
Time taken for tests:   4.662 seconds
Complete requests:      15000
Failed requests:        14909
   (Connect: 0, Receive: 0, Length: 14909, Exceptions: 0)
Total transferred:      1818846 bytes
HTML transferred:       78846 bytes
Requests per second:    3217.70 [#/sec] (mean)
Time per request:       31.078 [ms] (mean)
Time per request:       0.311 [ms] (mean, across all concurrent requests)
Transfer rate:          381.02 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1  22.6      0    1055
Processing:     0   24  86.4     14    1096
Waiting:        0   22  81.0     13    1091
Total:          0   25  89.2     14    1096

Percentage of the requests served within a certain time (ms)
  50%     14
  66%     18
  75%     21
  80%     23
  90%     28
  95%     35
  98%     45
  99%    343
 100%   1096 (longest request)
```

## After (O(logN))

```
❯ ab -c 100 -n 15000 http://localhost:8080/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 1500 requests
Completed 3000 requests
Completed 4500 requests
Completed 6000 requests
Completed 7500 requests
Completed 9000 requests
Completed 10500 requests
Completed 12000 requests
Completed 13500 requests
Completed 15000 requests
Finished 15000 requests


Server Software:
Server Hostname:        localhost
Server Port:            8080

Document Path:          /
Document Length:        2 bytes

Concurrency Level:      100
Time taken for tests:   3.181 seconds
Complete requests:      15000
Failed requests:        14989
   (Connect: 0, Receive: 0, Length: 14989, Exceptions: 0)
Total transferred:      1818863 bytes
HTML transferred:       78863 bytes
Requests per second:    4715.81 [#/sec] (mean)
Time per request:       21.205 [ms] (mean)
Time per request:       0.212 [ms] (mean, across all concurrent requests)
Transfer rate:          558.42 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   6.4      0     552
Processing:     0   21  51.4     14     593
Waiting:        0   20  49.9     13     593
Total:          0   21  51.7     14     594

Percentage of the requests served within a certain time (ms)
  50%     14
  66%     18
  75%     21
  80%     23
  90%     28
  95%     34
  98%     47
  99%    330
 100%    594 (longest request)

```
